### PR TITLE
add `html5: 1` to query params on `getVideoInfoPage` function

### DIFF
--- a/lib/info.js
+++ b/lib/info.js
@@ -326,6 +326,7 @@ const getVideoInfoPage = async(id, options) => {
       ps: 'default',
       gl: 'US',
       hl: options.lang || 'en',
+			html5: 1
     },
   });
   let body = await miniget(url, options.requestOptions).text();


### PR DESCRIPTION
I recently start having an error when using this lib.
Someone even opened an issue to this problem: https://github.com/ytdl-js/react-native-ytdl/issues/73

I found the solution on another issue on ytdl-core: https://github.com/fent/node-ytdl-core/issues/923#issuecomment-843365128

It consists on add the query param `html5=1` on `/lib/info.js`, on function getVideoInfoPage

If this param isn't used, the miniget return an empty string and then the `info` object don't have the information needed.
It ends with a `[TypeError: undefined is not an object (evaluating 'videoDetails.thumbnail.thumbnails')]` on `cleanVideoDetails` (`/lib/info-extras.js`) when trying access `videoDetails.thumbnail.thumbnails` seeing that `videoDetails.thumbnail` is undefined. (Also the others properties are empty, like formats)