### PR TITLE
add `html5` query param to `getVideoInfoPage` function on v4.8.0

### DIFF
--- a/lib/info.js
+++ b/lib/info.js
@@ -330,6 +330,7 @@ const getVideoInfoPage = async(id, options) => {
   url.searchParams.set('ps', 'default');
   url.searchParams.set('gl', 'US');
   url.searchParams.set('hl', options.lang || 'en');
+  url.searchParams.set('html5', 1);
   const body = await utils.exposedMiniget(url.toString(), options).text();
   let info = querystring.parse(body);
   info.player_response = findPlayerResponse('get_video_info', info);


### PR DESCRIPTION
Recently I opened a PR https://github.com/ytdl-js/react-native-ytdl/pull/75 to correct a bug that was happening with me and other users https://github.com/ytdl-js/react-native-ytdl/issues/73. 
This PR was merged on the v4.2.1.
Now the package upgrade to v4.8.0 but the param don't was used on this version.

