### PR TITLE
add `c` and `cver` params to `getVideoInfoPage` to fix 404 errors

### DIFF
--- a/lib/info.js
+++ b/lib/info.js
@@ -326,6 +326,8 @@ const VIDEO_EURL = 'https://youtube.googleapis.com/v/';
 const getVideoInfoPage = async(id, options) => {
   const url = new URL(`https://${INFO_HOST}${INFO_PATH}`);
   url.searchParams.set('video_id', id);
+  url.searchParams.set('c', 'TVHTML5');
+  url.searchParams.set('cver', '7.20190319');
   url.searchParams.set('eurl', VIDEO_EURL + id);
   url.searchParams.set('ps', 'default');
   url.searchParams.set('gl', 'US');


### PR DESCRIPTION
The `getVideoInfoPage` is having problems again.
This issues reports the error - https://github.com/ytdl-js/react-native-ytdl/issues/78#issuecomment-864398263.

After search on the issues in `node-ytdl-core` repository I found this solution  https://github.com/fent/node-ytdl-core/commit/d1f535712410eebd79a7468abd07d94f8c4ebe5a

It's simply more 2 parameters to the URL on `getVideoInfoPage` function:
* `c`: `TVHTML5`
* `cver`: `7.20190319` 

Without this parameters the constant `body` that is defined like that:
```
const body = await utils.exposedMiniget(url.toString(), options).text();
```
will be empty and throw the error